### PR TITLE
fix: preserve links pasted into table cells

### DIFF
--- a/packages/sdoc-editor/src/extension/plugins/table/plugin.js
+++ b/packages/sdoc-editor/src/extension/plugins/table/plugin.js
@@ -3,7 +3,7 @@ import { ReactEditor } from '@seafile/slate-react';
 import isHotkey from 'is-hotkey';
 import isUrl from 'is-url';
 import { INTERNAL_EVENT } from '../../../constants';
-import { replacePastedDataId } from '../../../node-id/helpers';
+import { removeCommentMarks, replacePastedDataId } from '../../../node-id/helpers';
 import EventBus from '../../../utils/event-bus';
 import ObjectUtils from '../../../utils/object-utils';
 import { ELEMENT_TYPE, KEYBOARD, PARAGRAPH, CLIPBOARD_FORMAT_KEY, CHECK_LIST_ITEM, ORDERED_LIST, UNORDERED_LIST, TABLE_ROW, TABLE, TABLE_CELL } from '../../constants';
@@ -19,19 +19,18 @@ import { getSelectedInfo, insertTableElement, removeTable, insertMultipleRowsAnd
 const INLINE_LINK_TYPES = [ELEMENT_TYPE.LINK, ELEMENT_TYPE.SDOC_LINK, ELEMENT_TYPE.FILE_LINK];
 
 const getInlineLinkNodes = (nodes) => {
-  const linkNodes = [];
-  const hasOnlyInlineLinkContent = (children) => {
-    return Array.isArray(children) && children.every((node) => {
-      if (Object.prototype.hasOwnProperty.call(node, 'text')) return node.text === '';
-      if (INLINE_LINK_TYPES.includes(node.type)) {
-        linkNodes.push(node);
-        return true;
-      }
-      return node.type === ELEMENT_TYPE.PARAGRAPH && hasOnlyInlineLinkContent(node.children);
-    });
-  };
+  if (!Array.isArray(nodes) || nodes.length !== 1 || nodes[0].type !== PARAGRAPH) return null;
 
-  return hasOnlyInlineLinkContent(nodes) && linkNodes.length ? linkNodes : null;
+  const { children } = nodes[0];
+  if (!Array.isArray(children)) return null;
+
+  const linkNodes = children.filter((node) => INLINE_LINK_TYPES.includes(node.type));
+  const hasOnlyOneLink = linkNodes.length === 1;
+  const hasOnlyEmptyTextAndLink = children.every((node) => {
+    return INLINE_LINK_TYPES.includes(node.type) || (Object.prototype.hasOwnProperty.call(node, 'text') && node.text === '');
+  });
+
+  return hasOnlyOneLink && hasOnlyEmptyTextAndLink ? linkNodes : null;
 };
 
 const withTable = (editor) => {
@@ -387,7 +386,8 @@ const withTable = (editor) => {
 
       const linkNodes = getInlineLinkNodes(parsedData);
       if (linkNodes && isInTableSameCell(newEditor)) {
-        return Transforms.insertNodes(newEditor, replacePastedDataId(linkNodes));
+        const cleanedLinkNodes = removeCommentMarks(linkNodes);
+        return Transforms.insertNodes(newEditor, replacePastedDataId(cleanedLinkNodes));
       }
     }
 

--- a/packages/sdoc-editor/src/extension/plugins/table/plugin.js
+++ b/packages/sdoc-editor/src/extension/plugins/table/plugin.js
@@ -1,17 +1,38 @@
 import { Editor, Transforms, Path, Element, Range } from '@seafile/slate';
 import { ReactEditor } from '@seafile/slate-react';
 import isHotkey from 'is-hotkey';
+import isUrl from 'is-url';
 import { INTERNAL_EVENT } from '../../../constants';
+import { replacePastedDataId } from '../../../node-id/helpers';
 import EventBus from '../../../utils/event-bus';
 import ObjectUtils from '../../../utils/object-utils';
 import { ELEMENT_TYPE, KEYBOARD, PARAGRAPH, CLIPBOARD_FORMAT_KEY, CHECK_LIST_ITEM, ORDERED_LIST, UNORDERED_LIST, TABLE_ROW, TABLE, TABLE_CELL } from '../../constants';
 import { getNodeType, getParentNode, getSelectedNodeByType, isLastNode, generateEmptyElement, focusEditor, getAboveBlockNode, isRangeAcrossBlocks, getStartPoint, getEndPoint, isStartPoint, isEndPoint, getTopLevelBlockNode } from '../../core';
+import { isImage } from '../../utils';
 import { TABLE_MAX_ROWS, EMPTY_SELECTED_RANGE, TABLE_ELEMENT, TABLE_ELEMENT_POSITION, TABLE_CELL_MIN_WIDTH, TABLE_ROW_MIN_HEIGHT } from './constants';
 import { getSelectedInfo, insertTableElement, removeTable, insertMultipleRowsAndColumns, setTableFragmentData,
   deleteTableRangeData, focusCell, deleteHandler, isTableLocation, isLastTableCell,
   deleteTableSelectCells,
   isAllInTable,
   isInTableSameCell } from './helpers';
+
+const INLINE_LINK_TYPES = [ELEMENT_TYPE.LINK, ELEMENT_TYPE.SDOC_LINK, ELEMENT_TYPE.FILE_LINK];
+
+const getInlineLinkNodes = (nodes) => {
+  const linkNodes = [];
+  const hasOnlyInlineLinkContent = (children) => {
+    return Array.isArray(children) && children.every((node) => {
+      if (Object.prototype.hasOwnProperty.call(node, 'text')) return node.text === '';
+      if (INLINE_LINK_TYPES.includes(node.type)) {
+        linkNodes.push(node);
+        return true;
+      }
+      return node.type === ELEMENT_TYPE.PARAGRAPH && hasOnlyInlineLinkContent(node.children);
+    });
+  };
+
+  return hasOnlyInlineLinkContent(nodes) && linkNodes.length ? linkNodes : null;
+};
 
 const withTable = (editor) => {
   const { insertBreak, deleteBackward, deleteForward, insertData, selectAll, normalizeNode, handleTab, getFragment,
@@ -363,11 +384,22 @@ const withTable = (editor) => {
         insertMultipleRowsAndColumns(newEditor, tableElement.children, tableElement.columns);
         return;
       }
+
+      const linkNodes = getInlineLinkNodes(parsedData);
+      if (linkNodes && isInTableSameCell(newEditor)) {
+        return Transforms.insertNodes(newEditor, replacePastedDataId(linkNodes));
+      }
     }
 
     const text = data.getData('text/plain');
     if (!text) return;
-    Editor.insertText(newEditor, text);
+
+    // Keep URL paste behavior consistent with normal text while preserving multi-cell paste behavior.
+    if (isUrl(text) && !isImage(text) && isInTableSameCell(newEditor)) {
+      return insertData(data);
+    }
+
+    return Editor.insertText(newEditor, text);
   };
 
   newEditor.insertFragment = (data) => {

--- a/packages/sdoc-editor/tests/extension/plugins/table/table.test.js
+++ b/packages/sdoc-editor/tests/extension/plugins/table/table.test.js
@@ -123,7 +123,12 @@ describe('table operations tests', () => {
       id: 'source-link-id',
       type,
       ...attributes,
-      children: [{ id: 'source-link-text-id', text: attributes.title }],
+      children: [{
+        id: 'source-link-text-id',
+        text: attributes.title,
+        sdoc_comment_test: true,
+        removed_test: true,
+      }],
     };
     const fragment = window.btoa(encodeURIComponent(JSON.stringify([{
       id: 'source-paragraph-id',
@@ -149,7 +154,43 @@ describe('table operations tests', () => {
     const [linkNode, linkPath] = Array.from(Node.descendants(editor)).find(([node]) => node.type === type);
     expect(linkNode).toMatchObject({ type, ...attributes, children: [{ text: attributes.title }] });
     expect(linkNode.id).not.toBe(sourceNode.id);
+    expect(linkNode.children[0]).not.toHaveProperty('sdoc_comment_test');
+    expect(linkNode.children[0]).not.toHaveProperty('removed_test');
     expect(Editor.parent(editor, linkPath)[0].type).toBe('table_cell');
+  });
+
+  it('does not flatten links copied from multiple paragraphs into a table cell', async () => {
+    const input = (
+      <editor>
+        <htable>
+          <htrow>
+            <htcell><htext><cursor /></htext></htcell>
+          </htrow>
+        </htable>
+      </editor>
+    );
+    const sourceParagraphs = [
+      {
+        type: 'paragraph',
+        children: [{ type: 'link', href: 'https://example.com/one', children: [{ text: 'First link' }] }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ type: 'link', href: 'https://example.com/two', children: [{ text: 'Second link' }] }],
+      },
+    ];
+    const fragment = window.btoa(encodeURIComponent(JSON.stringify(sourceParagraphs)));
+    const clipboardData = {
+      getData: (dataType) => dataType === 'application/x-slate-fragment' ? fragment : 'First link\nSecond link',
+      types: ['application/x-slate-fragment', 'text/plain'],
+    };
+    const editor = createSdocEditor(input, [LinkPlugin.editorPlugin, TablePlugin.editorPlugin]);
+
+    await editor.insertData(clipboardData);
+
+    const pastedLinks = Array.from(Node.descendants(editor)).filter(([node]) => node.type === 'link');
+    expect(pastedLinks).toHaveLength(0);
+    expect(Node.string(editor.children[0].children[0].children[0])).toBe('First link\nSecond link');
   });
 
   it('delete selection from empty paragraph to the first table cell keeps a valid selection', () => {

--- a/packages/sdoc-editor/tests/extension/plugins/table/table.test.js
+++ b/packages/sdoc-editor/tests/extension/plugins/table/table.test.js
@@ -1,7 +1,10 @@
 /** @jsx jsx */
-import { Editor, Range, Transforms } from '@seafile/slate';
+import { Editor, Node, Range, Transforms } from '@seafile/slate';
+import { withReact } from '@seafile/slate-react';
+import { FileLinkPlugin, HtmlPlugin, LinkPlugin, SdocLinkPlugin } from '../../../../src/extension/plugins';
 import TablePlugin from '../../../../src/extension/plugins/table';
 import { syncRemoveTable } from '../../../../src/extension/plugins/table/helpers';
+import withNodeId from '../../../../src/node-id';
 import { jsx, createSdocEditor, formatChildren } from '../../../core';
 
 describe('table operations tests', () => {
@@ -72,6 +75,81 @@ describe('table operations tests', () => {
 
     editor.deleteBackward();
     expect(formatChildren(editor.children)).toEqual(formatChildren(output.children));
+  });
+
+  it('pastes a URL in a table cell as a link', async () => {
+    const url = 'https://example.com/docs';
+    const input = (
+      <editor>
+        <htable>
+          <htrow>
+            <htcell><htext><cursor /></htext></htcell>
+          </htrow>
+        </htable>
+      </editor>
+    );
+    const clipboardData = {
+      getData: (type) => type === 'text/plain' ? url : '',
+      types: ['text/plain'],
+    };
+    const editor = createSdocEditor(input, [LinkPlugin.editorPlugin, TablePlugin.editorPlugin]);
+
+    await editor.insertData(clipboardData);
+
+    const [linkNode] = Array.from(Node.descendants(editor)).find(([node]) => node.type === 'link');
+    expect(linkNode).toMatchObject({
+      type: 'link',
+      href: url,
+      title: url,
+      children: [{ text: url }],
+    });
+  });
+
+  it.each([
+    ['link', { href: 'https://example.com/docs', title: 'Example docs' }],
+    ['sdoc_link', { doc_uuid: 'sdoc-uuid', title: 'Example SDoc' }],
+    ['file_link', { doc_uuid: 'file-uuid', title: 'Example file' }],
+  ])('pastes a copied SDoc %s node in a table cell without flattening it', async (type, attributes) => {
+    const input = (
+      <editor>
+        <htable>
+          <htrow>
+            <htcell><htext><cursor /></htext></htcell>
+          </htrow>
+        </htable>
+      </editor>
+    );
+    const sourceNode = {
+      id: 'source-link-id',
+      type,
+      ...attributes,
+      children: [{ id: 'source-link-text-id', text: attributes.title }],
+    };
+    const fragment = window.btoa(encodeURIComponent(JSON.stringify([{
+      id: 'source-paragraph-id',
+      type: 'paragraph',
+      children: [sourceNode],
+    }])));
+    const clipboardData = {
+      getData: (dataType) => dataType === 'application/x-slate-fragment' ? fragment : attributes.title,
+      types: ['application/x-slate-fragment', 'text/plain'],
+    };
+    const editor = createSdocEditor(input, [
+      withReact,
+      HtmlPlugin.editorPlugin,
+      LinkPlugin.editorPlugin,
+      TablePlugin.editorPlugin,
+      SdocLinkPlugin.editorPlugin,
+      FileLinkPlugin.editorPlugin,
+      withNodeId,
+    ]);
+
+    await editor.insertData(clipboardData);
+
+    const [linkNode, linkPath] = Array.from(Node.descendants(editor)).find(([node]) => node.type === type);
+    expect(linkNode).toMatchObject({ type, ...attributes, children: [{ text: attributes.title }] });
+    expect(linkNode.id).not.toBe(sourceNode.id);
+    expect(Editor.parent(editor, linkPath)[0].type).toBe('table_cell');
   });
 
   it('delete selection from empty paragraph to the first table cell keeps a valid selection', () => {


### PR DESCRIPTION
## Summary
- preserve URL and SDoc link nodes when pasting into table cells
- insert only inline link nodes from copied Slate fragments

## Testing
- npm test -- --runInBand