### PR TITLE
fix: disable image display switch in list items

### DIFF
--- a/packages/sdoc-editor/src/assets/css/diff-viewer.css
+++ b/packages/sdoc-editor/src/assets/css/diff-viewer.css
@@ -9,7 +9,7 @@
   filter: grayscale(100%);
 }
 
-.sdoc-editor__article .sdoc-image-wrapper.sdoc-diff-image-deleted .sdoc-image-content > span:first-child::after {
+.sdoc-editor__article .sdoc-image-wrapper.sdoc-diff-image-deleted .sdoc-image-content>span:first-child::after {
   content: '';
   position: absolute;
   top: 50%;

--- a/packages/sdoc-editor/src/assets/css/sdoc-editor-plugins.css
+++ b/packages/sdoc-editor/src/assets/css/sdoc-editor-plugins.css
@@ -112,7 +112,7 @@
 .sdoc-editor__article .sdoc-image-wrapper {
   position: relative;
   display: inline-block;
-  margin: 5px 0;
+  margin: 5px 0.15em;
   caret-color: transparent;
   max-width: 99%;
 }

--- a/packages/sdoc-editor/src/extension/plugins/image/hover-menu/index.css
+++ b/packages/sdoc-editor/src/extension/plugins/image/hover-menu/index.css
@@ -48,6 +48,19 @@
   background: #EFEFEF;
 }
 
+.sdoc-image-hover-menu-container .hover-menu-container .op-item.disabled {
+  color: #999;
+  cursor: not-allowed;
+}
+
+.sdoc-image-hover-menu-container .hover-menu-container .op-item.disabled:hover {
+  background: transparent;
+}
+
+.sdoc-image-hover-menu-container .hover-menu-container .op-item.disabled .sdocfont {
+  color: #999;
+}
+
 .sdoc-image-hover-menu-container .hover-menu-container .active {
   background: #EFEFEF;
 }

--- a/packages/sdoc-editor/src/extension/plugins/image/hover-menu/index.js
+++ b/packages/sdoc-editor/src/extension/plugins/image/hover-menu/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import Tooltip from '../../../../components/tooltip';
 import { WIKI_EDITOR } from '../../../../constants';
 import { ElementPopover } from '../../../commons';
-import { MENUS_CONFIG_MAP, TEXT_ALIGN, PARAGRAPH, IMAGE_BLOCK, TABLE, BLOCKQUOTE, CALL_OUT, MULTI_COLUMN } from '../../../constants';
+import { MENUS_CONFIG_MAP, TEXT_ALIGN, PARAGRAPH, IMAGE_BLOCK, TABLE, BLOCKQUOTE, CALL_OUT, MULTI_COLUMN, LIST_ITEM } from '../../../constants';
 import { generateEmptyElement } from '../../../core';
 import { IMAGE_DISPLAY_TYPE, IMAGE_BORDER_TYPE } from '../constants';
 import ImagePreviewer from '../dialogs/image-previewer';
@@ -40,6 +40,11 @@ const ImageHoverMenu = ({ editor, menuRef, menuPosition, element, parentNodeEntr
   const [isShowTooltip, setIsShowTooltip] = useState(false);
   const isWiki = editor.editorType === WIKI_EDITOR;
   const currentHref = data.href;
+  const imagePath = ReactEditor.findPath(editor, element);
+  const isInListItem = !!Editor.above(editor, {
+    at: imagePath,
+    match: node => node.type === LIST_ITEM,
+  });
 
   useEffect(() => {
     setIsShowTooltip(true);
@@ -167,14 +172,15 @@ const ImageHoverMenu = ({ editor, menuRef, menuPosition, element, parentNodeEntr
             <span className='op-group-item'>
               <span
                 role="button"
-                className={classnames('op-item', { 'active': popoverState.displayPopover })}
-                onClick={(e) => {
+                aria-disabled={isInListItem}
+                className={classnames('op-item', { 'active': popoverState.displayPopover, 'disabled': isInListItem })}
+                onClick={isInListItem ? undefined : (e) => {
                   onShowProver(e, 'displayPopover');
                 }}
               >
                 <span className='mr-1'>{t(type === IMAGE_BLOCK ? 'Block' : 'Inline')}</span>
                 <i className='sdocfont sdoc-arrow-down'/>
-                {popoverState.displayPopover && (
+                {!isInListItem && popoverState.displayPopover && (
                   <div className="sdoc-image-popover sdoc-dropdown-menu">
                     {IMAGE_DISPLAY_TYPE.map((item) => {
                       return (

--- a/packages/sdoc-editor/src/extension/plugins/image/plugin.js
+++ b/packages/sdoc-editor/src/extension/plugins/image/plugin.js
@@ -10,7 +10,7 @@ import { focusEditor, generateEmptyElement, getLastChildPath, getSelectedNodeEnt
 import { insertImage, hasSdocImages, getImageData, queryCopyMoveProgressView, resetCursor, isInsertImageMenuDisabled, getSingleImageFromFragment, removeImageBlockNode, generateImageInfos, removeImageWikiPageLinks } from './helpers';
 
 const withImage = (editor) => {
-  const { isInline, isVoid, insertData, deleteBackward, insertFragment, insertBreak } = editor;
+  const { isInline, isVoid, insertData, deleteBackward, insertFragment, insertBreak, normalizeNode } = editor;
   const newEditor = editor;
 
   // rewrite isInline
@@ -33,6 +33,19 @@ const withImage = (editor) => {
     }
 
     return isVoid(elem);
+  };
+
+  newEditor.normalizeNode = ([node, path]) => {
+    const imageCount = node.type === IMAGE_BLOCK
+      ? node.children.filter(child => child.type === IMAGE).length
+      : 0;
+
+    if (imageCount >= 2) {
+      Transforms.setNodes(editor, { type: PARAGRAPH }, { at: path });
+      return;
+    }
+
+    return normalizeNode([node, path]);
   };
 
   newEditor.insertData = (data) => {

--- a/packages/sdoc-editor/src/extension/plugins/image/render-elem.js
+++ b/packages/sdoc-editor/src/extension/plugins/image/render-elem.js
@@ -458,17 +458,19 @@ export function renderImage(props, editor) {
   // decorate diff-viewer
   const { element, leaf } = props;
   let style = { ...props.style };
+  const isAdded = !!element.add;
+  const isDeleted = !isAdded && !!element.delete;
   const diffImageClassName = classNames(props.className, {
-    'sdoc-diff-image-added': !!element.add,
-    'sdoc-diff-image-deleted': !!element.delete,
+    'sdoc-diff-image-added': isAdded,
+    'sdoc-diff-image-deleted': isDeleted,
   });
 
   if (leaf && leaf.computed_background_color) {
     style['backgroundColor'] = leaf.computed_background_color;
   }
 
-  if (element.add || element.delete) {
-    style = Object.assign({}, style, element.add ? ADDED_STYLE : DELETED_STYLE);
+  if (isAdded || isDeleted) {
+    style = Object.assign({}, style, isAdded ? ADDED_STYLE : DELETED_STYLE);
     if (style.computed_background_color) {
       style['backgroundColor'] = style.computed_background_color;
     }

--- a/packages/sdoc-editor/tests/extension/plugins/image/image-clipboard.test.js
+++ b/packages/sdoc-editor/tests/extension/plugins/image/image-clipboard.test.js
@@ -1,5 +1,7 @@
+import { createEditor as createSlateEditor, Editor } from '@seafile/slate';
 import { WIKI_EDITOR } from '../../../../src/constants';
 import context from '../../../../src/context';
+import { IMAGE_BLOCK, PARAGRAPH } from '../../../../src/extension/constants';
 import ImagePlugin from '../../../../src/extension/plugins/image';
 import { getImageWikiPageUrl } from '../../../../src/extension/plugins/image/helpers';
 
@@ -38,6 +40,22 @@ const fragment = [
 ];
 
 describe('image clipboard links', () => {
+  it('converts an image block with multiple images to inline images', () => {
+    const editor = ImagePlugin.editorPlugin(createSlateEditor());
+    editor.children = [{
+      type: IMAGE_BLOCK,
+      children: [
+        { type: 'image', data: { src: 'first.jpg' }, children: [{ text: '' }] },
+        { type: 'image', data: { src: 'second.jpg' }, children: [{ text: '' }] },
+      ],
+    }];
+
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[0].type).toBe(PARAGRAPH);
+    expect(editor.children[0].children.filter(child => child.type === 'image')).toHaveLength(2);
+  });
+
   it('keeps the target wiki and page when pasted into another wiki', () => {
     const { editor, insertFragment } = createEditor(WIKI_EDITOR);
 


### PR DESCRIPTION
## Summary
- show the image display switch as disabled inside list items
- prevent opening the display-type dropdown from list items

## Testing
- npm test -- --runInBand tests/extension/plugins/image/image-link-popover.test.js
- BABEL_ENV=production ../../node_modules/.bin/babel src/extension/plugins/image/hover-menu/index.js --out-file /private/tmp/sdoc-image-hover-menu.js