### PR TITLE
fix: scope deleted image styles to diff views

### DIFF
--- a/packages/sdoc-editor/src/assets/css/diff-viewer.css
+++ b/packages/sdoc-editor/src/assets/css/diff-viewer.css
@@ -4,12 +4,12 @@
   overflow: hidden;
 }
 
-.sdoc-editor__article .sdoc-image-wrapper.sdoc-diff-image-deleted img {
+#sdoc-editor[data-diff-view='true'] .sdoc-image-wrapper.sdoc-diff-image-deleted img {
   opacity: 0.55;
   filter: grayscale(100%);
 }
 
-.sdoc-editor__article .sdoc-image-wrapper.sdoc-diff-image-deleted .sdoc-image-content>span:first-child::after {
+#sdoc-editor[data-diff-view='true'] .sdoc-image-wrapper.sdoc-diff-image-deleted .sdoc-image-content>span:first-child::after {
   content: '';
   position: absolute;
   top: 50%;

--- a/packages/sdoc-editor/src/views/published-revision-diff-viewer.js
+++ b/packages/sdoc-editor/src/views/published-revision-diff-viewer.js
@@ -57,6 +57,7 @@ const PublishedRevisionDiffViewer = ({ isShowChanges, revisionContent, didMountC
       showToolbar={true}
       showOutline={true}
       showComment={false}
+      isDiffView={isShowChanges}
     />
   );
 

--- a/packages/sdoc-editor/src/views/readonly-article.js
+++ b/packages/sdoc-editor/src/views/readonly-article.js
@@ -7,7 +7,7 @@ import { renderElement, renderLeaf } from '../extension';
 import { SetNodeToDecorations } from '../highlight';
 import { ArticleContainer } from '../layout';
 
-const ReadOnlyArticle = ({ editor, slateValue, updateSlateValue, showComment = false }) => {
+const ReadOnlyArticle = ({ editor, slateValue, updateSlateValue, showComment = false, isDiffView = false }) => {
   const decorate = usePipDecorate(editor);
   const [, setVersion] = useState(0);
 
@@ -28,6 +28,7 @@ const ReadOnlyArticle = ({ editor, slateValue, updateSlateValue, showComment = f
           <SetNodeToDecorations />
           <Editable
             id='sdoc-editor'
+            data-diff-view={isDiffView ? 'true' : undefined}
             readOnly={true}
             placeholder=''
             renderElement={renderElement}
@@ -46,6 +47,7 @@ ReadOnlyArticle.propTypes = {
   editor: PropTypes.object,
   slateValue: PropTypes.array,
   updateSlateValue: PropTypes.func,
+  isDiffView: PropTypes.bool,
 };
 
 export default ReadOnlyArticle;

--- a/packages/sdoc-editor/src/views/revision-diff-viewer.js
+++ b/packages/sdoc-editor/src/views/revision-diff-viewer.js
@@ -56,6 +56,7 @@ const RevisionDiffViewer = ({ editor, revisionContent, didMountCallback, mathJax
         showToolbar={true}
         showOutline={true}
         showComment={true}
+        isDiffView={true}
       />
       <InsertElementDialog editor={editor} />
     </>

--- a/packages/sdoc-editor/src/views/sdoc-diff-viewer.js
+++ b/packages/sdoc-editor/src/views/sdoc-diff-viewer.js
@@ -33,6 +33,7 @@ const DiffViewer = ({ currentContent, lastContent, didMountCallback, mathJaxSour
       showOutline={false}
       showComment={false}
       editor={editor}
+      isDiffView={true}
     />
   );
 

--- a/packages/sdoc-editor/src/views/sdoc-viewer.js
+++ b/packages/sdoc-editor/src/views/sdoc-viewer.js
@@ -18,7 +18,7 @@ import ReadOnlyArticle from './readonly-article';
 import '../assets/css/sdoc-viewer.css';
 
 
-const SDocViewer = ({ editor, document, showToolbar = false, showOutline = false, showComment = false, plugins = [], enableMathJax = false, mathJaxSource = MATH_JAX_SOURCE_RUL }) => {
+const SDocViewer = ({ editor, document, showToolbar = false, showOutline = false, showComment = false, plugins = [], enableMathJax = false, mathJaxSource = MATH_JAX_SOURCE_RUL, isDiffView = false }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { isLoadingMathJax } = enableMathJax ? useMathJax(mathJaxSource) : { isLoadingMathJax: false };
 
@@ -53,7 +53,7 @@ const SDocViewer = ({ editor, document, showToolbar = false, showOutline = false
           <ColorProvider>
             {showToolbar && <HeaderToolbar editor={validEditor} readonly={true} />}
             <EditorContent docValue={slateValue} readonly={true} showOutline={showOutline} editor={validEditor} showComment={showComment}>
-              <ReadOnlyArticle editor={validEditor} slateValue={slateValue} />
+              <ReadOnlyArticle editor={validEditor} slateValue={slateValue} isDiffView={isDiffView} />
             </EditorContent>
           </ColorProvider>
         </EditorContainer>
@@ -69,6 +69,7 @@ SDocViewer.propTypes = {
   document: PropTypes.object,
   editor: PropTypes.object,
   plugins: PropTypes.array,
+  isDiffView: PropTypes.bool,
 };
 
 export default SDocViewer;


### PR DESCRIPTION
## Summary
- scope deleted-image grayscale and strike-through styles to diff views
- pass diff-view state through the read-only viewer chain

## Testing
- npm run test -- --runInBand