### PR TITLE
fix: remove File insertion menu logic

### DIFF
--- a/packages/sdoc-editor/src/extension/constants/menus-config.js
+++ b/packages/sdoc-editor/src/extension/constants/menus-config.js
@@ -39,7 +39,6 @@ import {
   TOGGLE_HEADER3,
   EMBED_LINK,
   DIVIDER,
-  FILE,
 } from './element-type';
 
 export const UNDO = 'undo';
@@ -426,12 +425,6 @@ export const SIDE_INSERT_MENUS_CONFIG = {
     type: LINK,
     text: 'Link'
   },
-  [FILE]: {
-    id: 'sdoc-side-menu-item-file-link',
-    iconClass: 'sdocfont sdoc-link-file',
-    type: FILE,
-    text: 'File'
-  },
   [EMBED_LINK]: {
     id: '',
     iconClass: 'sdocfont sdoc-embed-link',
@@ -556,7 +549,6 @@ export const SIDE_INSERT_MENUS_SEARCH_MAP = {
   [THREE_COLUMN]: 'Three_column',
   [FOUR_COLUMN]: 'Four_column',
   [LINK]: 'Link',
-  [FILE]: 'File',
   [CODE_BLOCK]: 'Code_block',
   [CALL_OUT]: 'Callout',
   [UNORDERED_LIST]: 'Unordered_list',
@@ -581,7 +573,6 @@ export const SIDE_QUICK_INSERT_MENUS_SEARCH_MAP = {
   [THREE_COLUMN]: 'Three_column',
   [FOUR_COLUMN]: 'Four_column',
   [LINK]: 'Link',
-  [FILE]: 'File',
   [CODE_BLOCK]: 'Code_block',
   [CALL_OUT]: 'Callout',
   [UNORDERED_LIST]: 'Unordered_list',

--- a/packages/sdoc-editor/src/extension/toolbar/quick-insert-toolbar/index.js
+++ b/packages/sdoc-editor/src/extension/toolbar/quick-insert-toolbar/index.js
@@ -5,7 +5,6 @@ import { Transforms } from '@seafile/slate';
 import { useSlateStatic } from '@seafile/slate-react';
 import PropTypes from 'prop-types';
 import { DOCUMENT_PLUGIN_EDITOR, INTERNAL_EVENT, KeyCodes, WIKI_EDITOR } from '../../../constants';
-import context from '../../../context';
 import { isMobile } from '../../../utils/common-utils';
 import EventBus from '../../../utils/event-bus';
 import DropdownMenuItem from '../../commons/dropdown-menu-item';
@@ -15,7 +14,6 @@ import { getAboveBlockNode } from '../../core';
 import { wrapCallout } from '../../plugins/callout/helper';
 import { setCheckListItemType } from '../../plugins/check-list/helpers';
 import { changeToCodeBlock } from '../../plugins/code-block/helpers';
-import { insertFileLink } from '../../plugins/file-link/helpers';
 import { toggleList } from '../../plugins/list/transforms';
 import { insertMultiColumn } from '../../plugins/multi-column/helper';
 import { insertTable } from '../../plugins/table/helpers';
@@ -42,8 +40,6 @@ const QuickInsertBlockMenu = ({
   const { t } = useTranslation('sdoc-editor');
   const [currentSelectIndex, setCurrentSelectIndex] = useState(-1); // -1 is input focus position
   const [quickInsertMenuSearchMap, setQuickInsertMenuSearchMap] = useState(SIDE_QUICK_INSERT_MENUS_SEARCH_MAP);
-
-  const hasLinkedRepos = context.hasLinkedRepos();
 
   const onInsertImageToggle = useCallback(() => {
     callback && callback();
@@ -102,16 +98,6 @@ const QuickInsertBlockMenu = ({
     eventBus.dispatch(INTERNAL_EVENT.INSERT_ELEMENT, { type: ELEMENT_TYPE.LINK, insertPosition, slateNode });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [insertPosition]);
-
-  const openSelectFileDialog = useCallback(() => {
-    callback && callback();
-    if (insertPosition === INSERT_POSITION.AFTER) {
-      insertElement(editor, PARAGRAPH, insertPosition);
-    }
-    const eventBus = EventBus.getInstance();
-    eventBus.dispatch(INTERNAL_EVENT.INSERT_ELEMENT, { type: ELEMENT_TYPE.FILE, insertFileLinkCallback: insertFileLink });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, insertPosition]);
 
   const addEmbedLinkDialog = useCallback(() => {
     callback && callback();
@@ -264,9 +250,6 @@ const QuickInsertBlockMenu = ({
           />
         </DropdownMenuItem>,
       [LINK]: <DropdownMenuItem isHidden={!quickInsertMenuSearchMap[LINK]} key="sdoc-insert-menu-link" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.LINK] }} onClick={openLinkDialog} />,
-      ...(editor.editorType === WIKI_EDITOR && hasLinkedRepos && {
-        [ELEMENT_TYPE.FILE]: <DropdownMenuItem isHidden={!quickInsertMenuSearchMap[ELEMENT_TYPE.FILE]} key="sdoc-insert-menu-file-link" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.FILE] }} onClick={openSelectFileDialog} />,
-      }),
       [EMBED_LINK]: <DropdownMenuItem isHidden={!quickInsertMenuSearchMap[EMBED_LINK]} key="sdoc-insert-menu-embed-link" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.EMBED_LINK] }} onClick={addEmbedLinkDialog} />,
       [CODE_BLOCK]: <DropdownMenuItem isHidden={!quickInsertMenuSearchMap[CODE_BLOCK]} disabled={isDisableCodeBlock} key="sdoc-insert-menu-code-block" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.CODE_BLOCK] }} onClick={onInsertCodeBlock} />,
       [CALL_OUT]: <DropdownMenuItem isHidden={!quickInsertMenuSearchMap[CALL_OUT]} disabled={isDisableCallout} key="sdoc-insert-menu-callout" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.CALL_OUT] }} onClick={() => onInsertCallout(PARAGRAPH)} />,
@@ -292,7 +275,7 @@ const QuickInsertBlockMenu = ({
 
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [quickInsertMenuSearchMap, isDisableImage, onInsertImageToggle, isDisableVideo, isDisableMultiColumn, onInsertVideoToggle, isDisableTable, editor, createTable, callback, handleClosePopover, openLinkDialog, openSelectFileDialog, addEmbedLinkDialog, onInsertCodeBlock, isDisableCallout, onInsertCheckList, isEmptyNode, onInsertCallout, onInsertList, onInsert, createMultiColumn, isDisableHeader, hasLinkedRepos]);
+  }, [quickInsertMenuSearchMap, isDisableImage, onInsertImageToggle, isDisableVideo, isDisableMultiColumn, onInsertVideoToggle, isDisableTable, editor, createTable, callback, handleClosePopover, openLinkDialog, addEmbedLinkDialog, onInsertCodeBlock, isDisableCallout, onInsertCheckList, isEmptyNode, onInsertCallout, onInsertList, onInsert, createMultiColumn, isDisableHeader]);
 
   const getSelectItemDom = (selectIndex) => {
     const dropDownItemWrapper = downDownWrapperRef.current;

--- a/packages/sdoc-editor/src/extension/toolbar/side-toolbar/insert-block-menu.js
+++ b/packages/sdoc-editor/src/extension/toolbar/side-toolbar/insert-block-menu.js
@@ -5,14 +5,12 @@ import { Transforms } from '@seafile/slate';
 import { useSlateStatic } from '@seafile/slate-react';
 import PropTypes from 'prop-types';
 import { DOCUMENT_PLUGIN_EDITOR, INTERNAL_EVENT, WIKI_EDITOR } from '../../../constants';
-import context from '../../../context';
 import EventBus from '../../../utils/event-bus';
 import DropdownMenuItem from '../../commons/dropdown-menu-item';
 import { ELEMENT_TYPE, INSERT_POSITION, LOCAL_IMAGE, LOCAL_VIDEO, PARAGRAPH, SIDE_INSERT_MENUS_CONFIG, SIDE_INSERT_MENUS_SEARCH_MAP } from '../../constants';
 import { wrapCallout } from '../../plugins/callout/helper';
 import { setCheckListItemType } from '../../plugins/check-list/helpers';
 import { changeToCodeBlock } from '../../plugins/code-block/helpers';
-import { insertFileLink } from '../../plugins/file-link/helpers';
 import { toggleList } from '../../plugins/list/transforms';
 import { insertMultiColumn } from '../../plugins/multi-column/helper';
 import { insertTable } from '../../plugins/table/helpers';
@@ -29,7 +27,6 @@ const InsertBlockMenu = ({
 }) => {
   const editor = useSlateStatic();
   const { t } = useTranslation('sdoc-editor');
-  const hasLinkedRepos = context.hasLinkedRepos();
 
   const onInsertImageToggle = useCallback(() => {
     const eventBus = EventBus.getInstance();
@@ -132,15 +129,6 @@ const InsertBlockMenu = ({
     insertMultiColumn(editor, editor.selection, newInsertPosition, type);
   }, [editor, insertPosition, slateNode]);
 
-  const openSelectFileDialog = useCallback(() => {
-    if (insertPosition === INSERT_POSITION.AFTER) {
-      insertElement(editor, PARAGRAPH, insertPosition);
-    }
-    const eventBus = EventBus.getInstance();
-    eventBus.dispatch(INTERNAL_EVENT.INSERT_ELEMENT, { type: ELEMENT_TYPE.FILE, insertFileLinkCallback: insertFileLink });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, insertPosition]);
-
   return (
     <>
       {[SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.PARAGRAPH], ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.HEADER]/* , ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.TOGGLE_HEADER]*/].map((item) => {
@@ -190,9 +178,6 @@ const InsertBlockMenu = ({
         />
       </DropdownMenuItem>
       <DropdownMenuItem isHidden={!insertMenuSearchMap[ELEMENT_TYPE.LINK]} menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.LINK] }} onClick={openLinkDialog} />
-      {editor.editorType === WIKI_EDITOR && hasLinkedRepos && (
-        <DropdownMenuItem isHidden={!insertMenuSearchMap[ELEMENT_TYPE.FILE]} key="sdoc-insert-menu-file-link" menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.FILE] }} onClick={openSelectFileDialog} />
-      )}
       <DropdownMenuItem isHidden={!insertMenuSearchMap[ELEMENT_TYPE.CODE_BLOCK]} menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.CODE_BLOCK] }} onClick={onInsertCodeBlock} />
       <DropdownMenuItem isHidden={!insertMenuSearchMap[ELEMENT_TYPE.CALL_OUT]} menuConfig={{ ...SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.CALL_OUT] }} onClick={() => onInsertCallout(PARAGRAPH)} />
       {SIDE_INSERT_MENUS_CONFIG[ELEMENT_TYPE.MULTI_COLUMN].map((item) => {


### PR DESCRIPTION
## Summary
- remove File from the right-click/side insertion menu
- remove File from the quick insertion menu
- preserve the existing FileLinkMenu and File link insertion flow

## Testing
- ESLint passed
- npm run build passed
- npm test passed: 103 suites, 300 tests
- git diff --check passed