### PR TITLE
fix(link): handle encoded file URLs

### DIFF
--- a/packages/sdoc-editor/src/extension/plugins/link/helpers.js
+++ b/packages/sdoc-editor/src/extension/plugins/link/helpers.js
@@ -191,23 +191,31 @@ export const unWrapLinkNode = (editor) => {
   });
 };
 
-export const isSdocFile = (res, url) => {
-  const { data: { files_info } } = res;
-  const fileInfo = files_info[url];
+export const decodeLinkUrl = (url) => {
+  try {
+    return decodeURIComponent(url);
+  } catch (e) {
+    return url;
+  }
+};
+
+export const getLinkFileInfo = (res, url) => {
+  const filesInfo = res?.data?.files_info || {};
+  const decodedUrl = decodeLinkUrl(url);
+  return filesInfo[decodedUrl] || filesInfo[url];
+};
+
+export const isSdocFile = (fileInfo) => {
   const { is_dir, file_ext } = fileInfo || {};
   return !is_dir && file_ext === 'sdoc';
 };
 
-export const isExdrawFile = (res, url) => {
-  const { data: { files_info } } = res;
-  const fileInfo = files_info[url];
+export const isExdrawFile = (fileInfo) => {
   const { is_dir, file_ext } = fileInfo || {};
   return !is_dir && file_ext === 'exdraw';
 };
 
-export const isCommonFile = (res, url) => {
-  const { data: { files_info } } = res;
-  const fileInfo = files_info[url];
+export const isCommonFile = (fileInfo) => {
   const { is_dir, file_ext } = fileInfo || {};
   return fileInfo && !is_dir && file_ext && !['sdoc', 'exdraw', 'video'].includes(file_ext);
 };

--- a/packages/sdoc-editor/src/extension/plugins/link/plugin.js
+++ b/packages/sdoc-editor/src/extension/plugins/link/plugin.js
@@ -12,7 +12,7 @@ import { insertFileLink } from '../file-link/helpers';
 import { insertSdocFileLink } from '../sdoc-link/helpers';
 import { insertWhiteboard } from '../whiteboard/helper';
 import { insertWikiPageLink } from '../wiki-link/helpers';
-import { genLinkNode, insertLink, isCommonFile, isExdrawFile, isSdocFile } from './helpers';
+import { genLinkNode, getLinkFileInfo, insertLink, isCommonFile, isExdrawFile, isSdocFile } from './helpers';
 
 const withLink = (editor) => {
   const { normalizeNode, isInline, insertData, insertFragment, onHotKeyDown, onCompositionStart } = editor;
@@ -40,19 +40,22 @@ const withLink = (editor) => {
       if (isSameDomain(text, context.getSetting('serviceUrl'))) {
         try {
           const res = await context.getLinkFilesInfo([text]);
-          if (isSdocFile(res, text)) {
-            const fileName = res.data.files_info[text].name;
-            const fileUuid = res.data.files_info[text].file_uuid;
+          const fileInfo = getLinkFileInfo(res, text);
+          if (fileInfo && isSdocFile(fileInfo)) {
+            const fileName = fileInfo.name;
+            const fileUuid = fileInfo.file_uuid;
             insertSdocFileLink(editor, fileName, fileUuid);
-          } else if (isExdrawFile(res, text)) {
-            const fileName = res.data.files_info[text].name;
-            const fileParentPath = res.data.files_info[text].parent_path;
+          } else if (fileInfo && isExdrawFile(fileInfo)) {
+            const fileName = fileInfo.name;
+            const fileParentPath = fileInfo.parent_path;
             const filePath = fileParentPath + '/' + fileName;
-            const repoId = res.data.files_info[text].repo_id;
+            const repoId = fileInfo.repo_id;
+
+            console.log('insertWhiteboard', fileName, filePath, repoId);
             insertWhiteboard(editor, fileName, filePath, repoId);
-          } else if (isCommonFile(res, text)) {
-            const fileName = res.data.files_info[text].name;
-            const fileUuid = res.data.files_info[text].file_uuid;
+          } else if (fileInfo && isCommonFile(fileInfo)) {
+            const fileName = fileInfo.name;
+            const fileUuid = fileInfo.file_uuid;
             insertFileLink(editor, fileName, fileUuid);
           } else {
             const url = new URL(text);

--- a/packages/sdoc-editor/tests/extension/plugins/link/helpers.test.js
+++ b/packages/sdoc-editor/tests/extension/plugins/link/helpers.test.js
@@ -1,0 +1,53 @@
+import {
+  decodeLinkUrl,
+  getLinkFileInfo,
+  isCommonFile,
+  isExdrawFile,
+  isSdocFile,
+} from '../../../../src/extension/plugins/link/helpers';
+
+describe('link file info helpers', () => {
+  const encodedUrl = 'https://example.com/f/repo/?p=%E4%B8%AD%E6%96%87';
+  const decodedUrl = decodeURIComponent(encodedUrl);
+
+  const createResponse = (file_ext) => ({
+    data: {
+      files_info: {
+        [decodedUrl]: {
+          file_ext,
+          is_dir: false,
+          file_uuid: 'file-uuid',
+        },
+      },
+    },
+  });
+
+  it('decodes an encoded link before looking up file info', () => {
+    const res = createResponse('sdoc');
+
+    expect(decodeLinkUrl(encodedUrl)).toBe(decodedUrl);
+    const fileInfo = getLinkFileInfo(res, encodedUrl);
+
+    expect(fileInfo).toEqual(res.data.files_info[decodedUrl]);
+    expect(isSdocFile(fileInfo)).toBe(true);
+  });
+
+  it('uses the decoded URL for all supported file types', () => {
+    expect(isExdrawFile(getLinkFileInfo(createResponse('exdraw'), encodedUrl))).toBe(true);
+    expect(isCommonFile(getLinkFileInfo(createResponse('pdf'), encodedUrl))).toBe(true);
+  });
+
+  it('falls back to the original URL when it cannot be decoded', () => {
+    const url = 'https://example.com/f/repo/?p=%';
+    const res = {
+      data: {
+        files_info: {
+          [url]: { file_ext: 'sdoc', is_dir: false },
+        },
+      },
+    };
+
+    expect(decodeLinkUrl(url)).toBe(url);
+    expect(isSdocFile(getLinkFileInfo(res, url))).toBe(true);
+  });
+});

--- a/packages/sdoc-editor/tests/extension/plugins/link/toggle-link.test.js
+++ b/packages/sdoc-editor/tests/extension/plugins/link/toggle-link.test.js
@@ -1,12 +1,15 @@
 /** @jsx jsx */
 import { withReact } from '@seafile/slate-react';
+import context from '../../../../src/context';
 import { LinkPlugin } from '../../../../src/extension/plugins';
 import {
   insertLink,
   updateLink,
   unWrapLinkNode,
 } from '../../../../src/extension/plugins/link/helpers';
+import * as sdocLinkHelpers from '../../../../src/extension/plugins/sdoc-link/helpers';
 import { jsx, createSdocEditor, formatChildren } from '../../../core';
+
 
 describe('toggle link test', () => {
   describe('insert link menu when not selected', () => {
@@ -226,5 +229,46 @@ describe('modify link test', () => {
     expect(formatChildren(editor.children)).toEqual(
       formatChildren(output.children)
     );
+  });
+});
+
+describe('paste encoded internal file link', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('looks up file info with the decoded URL', async () => {
+    const encodedUrl = 'https://example.com/f/repo/?p=%E4%B8%AD%E6%96%87';
+    const decodedUrl = decodeURIComponent(encodedUrl);
+    const insertSdocFileLink = jest.spyOn(sdocLinkHelpers, 'insertSdocFileLink').mockImplementation(() => {});
+    const getLinkFilesInfo = jest.spyOn(context, 'getLinkFilesInfo').mockResolvedValue({
+      data: {
+        files_info: {
+          [decodedUrl]: {
+            file_ext: 'sdoc',
+            file_uuid: 'sdoc-uuid',
+            is_dir: false,
+            name: '中文.sdoc',
+          },
+        },
+      },
+    });
+    context.initSSRSettings({ serviceUrl: 'https://example.com' });
+
+    const input = (
+      <editor>
+        <hp><cursor /></hp>
+        <hp><htext></htext></hp>
+      </editor>
+    );
+    const editor = createSdocEditor(input, [withReact, LinkPlugin.editorPlugin]);
+
+    await editor.insertData({
+      getData: (type) => type === 'text/plain' ? encodedUrl : '',
+      types: ['text/plain'],
+    });
+
+    expect(getLinkFilesInfo).toHaveBeenCalledWith([encodedUrl]);
+    expect(insertSdocFileLink).toHaveBeenCalledWith(editor, '中文.sdoc', 'sdoc-uuid');
   });
 });


### PR DESCRIPTION
## Summary
- decode encoded internal file URLs before looking up file info
- pass the resolved fileInfo directly to file type checks
- preserve ordinary URL fallback behavior when fileInfo is unavailable

## Testing
- npm test -- --runInBand tests/extension/plugins/link/toggle-link.test.js tests/extension/plugins/link/helpers.test.js
- pre-commit ESLint hook passed