### PR TITLE
fix: make wiki outline height content driven

### DIFF
--- a/packages/sdoc-editor/src/outline/style.css
+++ b/packages/sdoc-editor/src/outline/style.css
@@ -16,8 +16,11 @@
 
 .wiki-outline-wrapper {
   position: fixed;
+  top: 100px;
   right: 0;
+  bottom: auto;
   left: unset;
+  height: auto;
   margin: 0;
   pointer-events: unset !important;
   flex: none;


### PR DESCRIPTION
## Summary
- make the wiki outline height follow its content
- keep the outline capped at 400px
- override the inherited bottom constraint from the fixed outline wrapper

## Testing
- npm test -- --runInBand
- npx eslint src/outline/wiki-outline.js
- Babel compile for src/outline
- git diff --check